### PR TITLE
[#52] Added column for url and include known urls

### DIFF
--- a/licenses.py
+++ b/licenses.py
@@ -83,7 +83,7 @@ license_names = {
     'xnet': 'OSI Approved::X.Net License',
     'zpl': 'OSI Approved::Zope Public License',
     'zlib-license': 'OSI Approved::zlib/libpng license'}
-   
+
 license_url = {
     'cc-nc': 'https://licenses.opendefinition.org/licenses/CC-BY-NC-4.0.json',
     'cc-by': 'http://www.opendefinition.org/licenses/cc-by',

--- a/licenses.py
+++ b/licenses.py
@@ -83,6 +83,20 @@ license_names = {
     'xnet': 'OSI Approved::X.Net License',
     'zpl': 'OSI Approved::Zope Public License',
     'zlib-license': 'OSI Approved::zlib/libpng license'}
+    
+license_url = {
+    'cc-nc': 'https://licenses.opendefinition.org/licenses/CC-BY-NC-4.0.json',
+    'cc-by': 'http://www.opendefinition.org/licenses/cc-by',
+    'cc-by-sa': 'http://www.opendefinition.org/licenses/cc-by-sa',
+    'cc-zero': 'http://www.opendefinition.org/licenses/cc-zero',
+    'odc-by': 'http://www.opendefinition.org/licenses/odc-by',
+    'odc-odbl': 'http://www.opendefinition.org/licenses/odc-odbl',
+    'odc-pddl': 'http://www.opendefinition.org/licenses/odc-pddl',
+    'other-at': 'https://licenses.opendefinition.org/licenses/other-at.json',
+    'other-open': 'https://licenses.opendefinition.org/licenses/other-open.json',
+    'other-pd': 'https://licenses.opendefinition.org/licenses/other-pd.json',
+    'other-nc': 'https://licenses.opendefinition.org/licenses/other-nc.json',
+    'uk-ogl': 'http://reference.data.gov.uk/id/open-government-licence'}
 
 with open('./stats-calculated/ckan.json') as handler:
     ckan = json.load(handler, object_pairs_hook=OrderedDict)
@@ -119,6 +133,7 @@ def main():
     licenses_per_publisher = [license for license, publisher in licenses_and_publisher]
     return render_template('licenses.html',
                            license_names=license_names,
+                           license_url=license_url,
                            license_count=dict((x, licenses.count(x)) for x in set(licenses)),
                            publisher_license_count=dict((x, licenses_per_publisher.count(x)) for x in set(licenses_per_publisher)),
                            sorted=sorted,
@@ -138,6 +153,7 @@ def individual_license(license):
                            url=lambda x: '../' + x,
                            license=license,
                            license_names=license_names,
+                           license_url=license_url,
                            publisher_counts=publisher_counts,
                            page='licenses',
                            licenses=True)

--- a/licenses.py
+++ b/licenses.py
@@ -83,7 +83,7 @@ license_names = {
     'xnet': 'OSI Approved::X.Net License',
     'zpl': 'OSI Approved::Zope Public License',
     'zlib-license': 'OSI Approved::zlib/libpng license'}
-    
+   
 license_url = {
     'cc-nc': 'https://licenses.opendefinition.org/licenses/CC-BY-NC-4.0.json',
     'cc-by': 'http://www.opendefinition.org/licenses/cc-by',

--- a/templates/licenses.html
+++ b/templates/licenses.html
@@ -8,10 +8,11 @@
             <p>Count of publishers per licences in use on the IATI Registry.</p>
             {% include '_partials/tablesorter_instructions.html' %}
           </div>
-          <table class="table table-striped">
+          <table class="table table-sm table-striped">
             <thead>
                 <tr>
                     <th>License Name</th>
+                    <th>License Url</th>
                     <th>License Id</th>
                     <th>Files</th>
                     <th>Publishers</th>
@@ -21,6 +22,7 @@
                 {% for license, files in sorted(license_count.items()) %}
                 <tr>
                     <td><a href="license/{{ license }}.html">{{ license_names[license] }}</a></td>
+                    <td><a href="license/{{ license }}.html">{{ license_url[license] }}</a></td>
                     <td><a href="license/{{ license }}.html">{{ license }}</a></td>
                     <td>{{ files }}</td>
                     <td>{{ publisher_license_count[license] }}</td>

--- a/templates/licenses.html
+++ b/templates/licenses.html
@@ -12,7 +12,6 @@
             <thead>
                 <tr>
                     <th>License Name</th>
-                    <th>License Url</th>
                     <th>License Id</th>
                     <th>Files</th>
                     <th>Publishers</th>
@@ -21,8 +20,7 @@
             <tbody>
                 {% for license, files in sorted(license_count.items()) %}
                 <tr>
-                    <td><a href="license/{{ license }}.html">{{ license_names[license] }}</a></td>
-                    <td><a href="license/{{ license }}.html">{{ license_url[license] }}</a></td>
+                    <td><a href="{{ license_url[license] }}">{{ license_names[license] }}</a></td>
                     <td><a href="license/{{ license }}.html">{{ license }}</a></td>
                     <td>{{ files }}</td>
                     <td>{{ publisher_license_count[license] }}</td>


### PR DESCRIPTION
Made a start to this, hope it's ok.

It looks like the license_names are added manually so have followed accordingly and just added the license_url that we know are being used to `licenses.py`.

There is also now a License Url column with the new data - the Unspecified licenses have no url so have left that empty.