### PR TITLE
Pin markupsafe dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ matplotlib==2.2.5
 requests
 Werkzeug==0.12.2
 xmlschema==1.6.2
+markupsafe==2.0.1


### PR DESCRIPTION
Pin markupsafe dependency to overcome error in `Build HTML output`:
```
ImportError: cannot import name 'soft_unicode' from 'markupsafe' 
```

Solution according to:
https://github.com/aws/aws-sam-cli/issues/3661