### PR TITLE
Use `url_for` to generate URLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,6 @@ jobs:
       run: python make_html.py
     - name: Delete files
       run: rm -rf data stats-calculated
-    - name: Add static files to output
-      run: cp -r static/* out
     - name: Deploy (production) 🚀
       if: github.ref == 'refs/heads/main'
       uses: JamesIves/github-pages-deploy-action@v4

--- a/make_html.py
+++ b/make_html.py
@@ -39,7 +39,7 @@ from data import (
     is_valid_element,
     slugs)
 
-app = Flask(__name__, static_folder='')
+app = Flask(__name__, static_url_path='')
 
 
 def dictinvert(d):

--- a/make_html.py
+++ b/make_html.py
@@ -365,9 +365,7 @@ if __name__ == '__main__':
                         'slug': slug,
                         'major_version': major_version
                     }
-            for license in licenses.licenses:
-                if license is None:
-                    license = 'None'
+            for license in set(licenses.licenses):
                 yield 'licenses_individual_license', {'license': license}
 
         freezer.freeze()

--- a/make_html.py
+++ b/make_html.py
@@ -39,7 +39,7 @@ from data import (
     is_valid_element,
     slugs)
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='')
 
 
 def dictinvert(d):

--- a/make_html.py
+++ b/make_html.py
@@ -264,7 +264,6 @@ def publisher(publisher):
                           ]
     failure_count = len(current_stats['inverted_file_publisher'][publisher]['validation'].get('fail', {}))
     return render_template('publisher.html',
-                           url=lambda x: '../' + x,
                            publisher=publisher,
                            publisher_stats=publisher_stats,
                            failure_count=failure_count,
@@ -282,7 +281,6 @@ def codelist(major_version, slug):
                            element=element,
                            values=values,
                            reverse_codelist_mapping={major_version: dictinvert(mapping) for major_version, mapping in codelist_mapping.items()},
-                           url=lambda x: '../../' + x,
                            major_version=major_version,
                            page='codelists')
 
@@ -295,7 +293,6 @@ def element(slug):
     return render_template('element.html',
                            element=element,
                            publishers=publishers,
-                           url=lambda x: '../' + x,
                            element_or_attribute='attribute' if '@' in element else 'element',
                            page='elements')
 

--- a/make_html.py
+++ b/make_html.py
@@ -115,11 +115,11 @@ date_time_data_obj = parser.parse(metadata['created_at'])
 # Custom Jinja filters
 app.jinja_env.filters['xpath_to_url'] = xpath_to_url
 app.jinja_env.filters['url_to_filename'] = lambda x: x.rstrip('/').split('/')[-1]
-app.jinja_env.filters['dataset_to_publisher'] = dataset_to_publisher
 app.jinja_env.filters['has_future_transactions'] = timeliness.has_future_transactions
 app.jinja_env.filters['round_nicely'] = round_nicely
 
 # Custom Jinja globals
+app.jinja_env.globals['dataset_to_publisher'] = dataset_to_publisher
 app.jinja_env.globals['url'] = lambda x: '/' if x == 'index.html' else x
 app.jinja_env.globals['datetime_generated'] = lambda: datetime.utcnow().replace(tzinfo=pytz.utc).strftime('%-d %B %Y (at %H:%M %Z)')
 app.jinja_env.globals['datetime_data'] = date_time_data_obj.strftime('%-d %B %Y (at %H:%M %Z)')

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,15 +26,16 @@
       </div>
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-        {% for item in top_navigation %}
-            <li {% if item==page or page in navigation[item] %}class="active"{% endif %}><a href="{{ url(item+'.html') }}">{{ top_titles[item] }}</a></li>
-        {% endfor %}
+          <li {% if page=='index' %}class="active"{% endif %}><a href="{{ url_for('homepage') }}">{{ top_titles['index'] }}</a></li>
+          {% for item in top_navigation %}
+          <li {% if item==page or page in navigation[item] %}class="active"{% endif %}><a href="{{ url_for('basic_page', page_name=item) }}">{{ top_titles[item] }}</a></li>
+          {% endfor %}
         </ul>
       </div>
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
         {% for item in navigation[navigation_reverse[page]] %}
-            <li{% if item==page %} class="active"{% endif %}><a href="{{ url(item+'.html') }}">{{ short_page_titles[item] }}</a></li>
+            <li{% if item==page %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name=item) }}">{{ short_page_titles[item] }}</a></li>
         {% endfor %}
         </ul>
       </div><!--/.nav-collapse -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,8 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" />
-  <link rel="stylesheet" type="text/css" href="/style.css" />
-  <link rel="icon" href="/favicon.ico">
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}" />
+  <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <title>{% block title %}{{ page_titles[page] }} – Code for IATI Analytics{% endblock %}</title>
 
   {% block extrahead %}{% endblock %}
@@ -72,7 +72,7 @@
 
           (NB This is the time the download task started. Any changes made after this time may not be reflected).<br />
 
-          For details on how often these updates are applied, see the <a href="/faq.html">Code for IATI Analytics FAQ</a>.
+          For details on how often these updates are applied, see the <a href="{{ url_for('basic_page', page_name='faq') }}">Code for IATI Analytics FAQ</a>.
     </div>
 </div>
 

--- a/templates/codelist.html
+++ b/templates/codelist.html
@@ -45,7 +45,7 @@
                   <tr><td>{{ value }}</td>
                     <td>{{ codelist_lookup[major_version].get(codelist_mapping[major_version].get(element))[value]['name'] }}</td>
                     <td>
-                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in sorted(publishers.items()) %}<a href='../../publisher/{{ publisher }}.html#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
+                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in sorted(publishers.items()) %}<a href='{{ url_for('publisher', publisher=publisher) }}#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
                   </td></tr>
                   {% endif %}
               {% endfor %}
@@ -68,7 +68,7 @@
               {% for value, publishers in values.items() %}
                   {% if not value in codelist_sets[major_version].get(codelist_mapping[major_version].get(element)) %}
                   <tr><td>{{ value }}</td><td>
-                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in sorted(publishers.items()) %}<a href='../../publisher/{{ publisher }}.html#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
+                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in sorted(publishers.items()) %}<a href='{{ url_for('publisher', publisher=publisher) }}#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
                   </td></tr>
                   {% endif %}
               {% endfor %}

--- a/templates/codelists.html
+++ b/templates/codelists.html
@@ -27,15 +27,15 @@
             <tbody>
               {% for i, (element, values) in enumerate(current_stats.inverted_publisher.codelist_values_by_major_version[major_version].items()) %}
                 <tr>
-                  <td><a href="codelist/{{ major_version }}/{{ slugs.codelist[major_version].by_i[i] }}.html">{{ element }}</td>
+                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ element }}</td>
                   <td><a href="https://codelists.codeforiati.org/{{ codelist_mapping[major_version].get(element) }}">{{ codelist_mapping[major_version].get(element) }}</a></td>
-                  <td><a href="codelist/{{ major_version }}/{{ slugs.codelist[major_version].by_i[i] }}.html">{{ values|length }}</a></td>
+                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ values|length }}</a></td>
                   <td><a href="https://codelists.codeforiati.org/{{ codelist_mapping[major_version].get(element) }}">{{ codelist_sets[major_version].get(codelist_mapping[major_version].get(element))|length }}</a></td>
                   {% with codes=sorted(codelist_sets[major_version].get(codelist_mapping[major_version].get(element)).intersection(get_codelist_values(values))) %}
-                  <td><a href="codelist/{{ major_version }}/{{ slugs.codelist[major_version].by_i[i] }}.html">{{ codes|length }}</a></td>
+                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ codes|length }}</a></td>
                   {% endwith %}
                   {% with codes=sorted(set(get_codelist_values(values)).difference(codelist_sets[major_version].get(codelist_mapping[major_version].get(element)))) %}
-                  <td><a href="codelist/{{ major_version }}/{{ slugs.codelist[major_version].by_i[i] }}.html">{{ codes|length }}</a></td>
+                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ codes|length }}</a></td>
                   {% endwith %}
                 </tr>
               {% endfor %}

--- a/templates/comprehensiveness_base.html
+++ b/templates/comprehensiveness_base.html
@@ -8,10 +8,10 @@
     {% endblock %}
 
     <ul class="nav nav-tabs" role="tablist">
-      <li{% if tab=='summary' %} class="active"{% endif %}><a href="comprehensiveness.html">Summary</a></li>
-      <li{% if tab=='core' %} class="active"{% endif %}><a href="comprehensiveness_core.html">Core</a></li>
-      <li{% if tab=='financials' %} class="active"{% endif %}><a href="comprehensiveness_financials.html">Financials</a></li>
-      <li{% if tab=='valueadded' %} class="active"{% endif %}><a href="comprehensiveness_valueadded.html">Value added</a></li>
+      <li{% if tab=='summary' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness') }}">Summary</a></li>
+      <li{% if tab=='core' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness_core') }}">Core</a></li>
+      <li{% if tab=='financials' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness_financials') }}">Financials</a></li>
+      <li{% if tab=='valueadded' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness_valueadded') }}">Value added</a></li>
     </ul>
 
     <ul class="list-inline" style="padding: 1em">
@@ -54,7 +54,7 @@
         <tbody>
             {% for row in comprehensiveness.table() %}
             <tr>
-                <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="publisher/{{ row.publisher }}.html">{{ row.publisher_title }}</a></td>
+                <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=row.publisher) }}">{{ row.publisher_title }}</a></td>
                 {% for column_slug in comprehensiveness.column_slugs[tab] %}
                 <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;">{% if column_slug in row %}
                     {{ row[column_slug+'_valid'] | round_nicely }}

--- a/templates/comprehensiveness_base.html
+++ b/templates/comprehensiveness_base.html
@@ -31,7 +31,7 @@
     {% block content %}
     <div class="panel panel-default" id="h_table">
     <div class="panel-heading">
-        <span class="pull-right"><a href="{{ url('comprehensiveness_'+tab+'.csv') }}">(This table as CSV)</a></span>
+        <span class="pull-right"><a href="{{ url_for('static', filename='comprehensiveness_{}.csv'.format(tab)) }}">(This table as CSV)</a></span>
         <h3 class="panel-title">{% block table_title %}Table of Comprehensiveness values{% endblock %}</h3>
     </div>
 

--- a/templates/comprehensiveness_core.html
+++ b/templates/comprehensiveness_core.html
@@ -5,7 +5,7 @@
 {% block heading_detail %}
 	<p>Core elements are those that are mandatory in version 2.01 of the IATI Activity standard. The core elements are: Version, Reporting Organisation, IATI Identifier, Participating Organisation, Title, Description, Status, Activity Date, Sector, and Country or Region.</p>
 
-	<p>This table shows the percentage of <strong><em>current</em></strong> activities where the core elements are populated with valid data. (Values in parentheses indicate percentage of activities where elements are populated with any data.) The scoring for the <a href="summary_stats.html">Summary Stats page</a> recognises the importance of the core by giving it double weighting in the overall comprehensiveness component.</p>
+	<p>This table shows the percentage of <strong><em>current</em></strong> activities where the core elements are populated with valid data. (Values in parentheses indicate percentage of activities where elements are populated with any data.) The scoring for the <a href="{{ url_for('basic_page', page_name='summary_stats') }}">Summary Stats page</a> recognises the importance of the core by giving it double weighting in the overall comprehensiveness component.</p>
 
 	<p><strong>Key:</strong><br/>
         Dashes: Where a publisher has published to IATI in the past but whose portfolio contains no current activities.

--- a/templates/coverage.html
+++ b/templates/coverage.html
@@ -10,7 +10,7 @@
 
         <p>
             Previously, the IATI technical team followed a manual process of contacting IATI publishers and requesting total operational spend values via email.
-            Results were stored in a <a href="https://docs.google.com/spreadsheets/d/1SgE6sXbzD2y8p3QzBcY4kAqkCTG1eUld5QuSvCfKVUE/edit#gid=2132486785">public Google sheet</a>. Data was collected for the years 2014 and 2015 and the values were used to calculate a coverage-adjusted score in the <a href="/summary_stats.html">Summary Statistics page.</a>
+            Results were stored in a <a href="https://docs.google.com/spreadsheets/d/1SgE6sXbzD2y8p3QzBcY4kAqkCTG1eUld5QuSvCfKVUE/edit#gid=2132486785">public Google sheet</a>. Data was collected for the years 2014 and 2015 and the values were used to calculate a coverage-adjusted score in the <a href="{{ url_for('basic_page', page_name='summary_stats') }}">Summary Statistics page.</a>
             As this was a very time consuming exercise (compounded by the increase in the number of publishers) coverage data collection has not been done since 2016, resulting in the coverage-adjusted scores in the summary statistics being out of date for the majority of publishers.
             As a result, in <a href="https://discuss.iatistandard.org/t/iati-coverage-timing-and-scope-of-next-update/1141/15">September 2018 the technical team took the decision</a> to remove the coverage-adjusted values.
         </p>

--- a/templates/dates.html
+++ b/templates/dates.html
@@ -19,7 +19,7 @@
               {% for publisher_title,publisher in publishers_ordered_by_title %}
               {% set publisher_stats = get_publisher_stats(publisher) %}
                   <tr>
-                      <td><a href="publisher/{{ publisher }}.html">{{ publisher_title }}</a></td>
+                      <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
                       <td>{% if publisher_stats.date_extremes.min.overall %}{{ publisher_stats.date_extremes.min.overall }}{% endif %}</td>
                       <td>{% if publisher_stats.date_extremes.max.overall %}{{ publisher_stats.date_extremes.max.overall }}{% endif %}</td>
                       <td>{% if publisher_stats.date_extremes.max.by_type['start-actual'] %}{{ publisher_stats.date_extremes.max.by_type['start-actual'] }}{% endif %}</td>

--- a/templates/download.html
+++ b/templates/download.html
@@ -29,7 +29,7 @@
             <tbody>
               {% for code, publisher, dataset, url in current_stats.download_errors %}
               <tr>
-                <td><a href="publisher/{{ publisher }}.html">{{ publisher }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
                 <td><a href="http://iatiregistry.org/dataset/{{ dataset }}">{{ dataset }}</a></td>
                 <td><a href="{{ url }}">{{ url|url_to_filename }}</a></td>
                 <td>{{ code }}</td>

--- a/templates/download.html
+++ b/templates/download.html
@@ -10,7 +10,7 @@
       <div class="col-xs-12">
         <p><a href="https://gist.github.com/codeforIATIbot/f117c9be138aa94c9762d57affc51a64/revisions">History of Download Errors</a></p>
 
-        <p><a href="{{ url('data/download_errors.json') }}">This table as JSON</a></p>
+        <p><a href="{{ url_for('static', filename='data/download_errors.json') }}">This table as JSON</a></p>
 
         <div class="panel panel-default">
           <div class="panel-body">

--- a/templates/element.html
+++ b/templates/element.html
@@ -38,7 +38,7 @@
           <tbody>
             {% for publisher in sorted(publishers) %}
             <tr>
-                <td><a href="{{ url('publisher/{0}.html'.format(publisher)) }}">{{ publisher }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
                 {% with publisher_inverted=get_publisher_stats(publisher, 'inverted-file') %}
                 <td><a href="#files_{{ publisher }}">{% if 'elements' in publisher_inverted %}{{ publisher_inverted.elements[element]|count }}{% endif %}</a></td>
                 {% endwith %}
@@ -71,7 +71,7 @@
             {% for publisher in current_stats.inverted_publisher.publishers %}
             {% if publisher not in publishers %}
             <tr>
-                <td><a href="{{ url('publisher/{0}.html'.format(publisher)) }}">{{ publisher }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
                 <td>{{ current_stats.inverted_publisher.activity_files.get(publisher)+current_stats.inverted_publisher.organisation_files.get(publisher) }}</td>
                 <td>{{ current_stats.inverted_publisher.activities[publisher] }}</td>
                 <td>{{ current_stats.inverted_publisher.organisations[publisher] }}</td>
@@ -98,7 +98,7 @@
             {% for publisher in current_stats.inverted_file_publisher %}
               {% with datasets = current_stats.inverted_file_publisher[publisher].elements.get(element) %}
               {% if datasets %}
-                <tr><td id="files_{{ publisher }}"><a href="{{ url('publisher/{0}.html'.format(publisher)) }}">{{ publisher }}</a></td><td>
+                <tr><td id="files_{{ publisher }}"><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td><td>
                 {% for dataset in datasets.keys() %}
                     <a href="http://iatiregistry.org/dataset/{{ dataset[:-4] }}">{{ dataset[:-4] }}</a>
                 {% endfor %}

--- a/templates/elements.html
+++ b/templates/elements.html
@@ -6,8 +6,8 @@
     <div class="panel panel-default">
         <div class="panel-body">
             <p>Download this data as CSV: <ul>
-                <li><a href="elements.csv">Activities/Orgs with element/attribute per publisher</a></li>
-                <li><a href="elements_total.csv">Total instances of element/attribute per publisher</a></li>
+                <li><a href="{{ url_for('static', filename='elements.csv') }}">Activities/Orgs with element/attribute per publisher</a></li>
+                <li><a href="{{ url_for('static', filename='elements_total.csv') }}">Total instances of element/attribute per publisher</a></li>
             </ul></p>
         </div>
     </div>
@@ -39,8 +39,8 @@
               {% for i, (element,publishers) in enumerate(current_stats.inverted_publisher.elements.items()) %}
               {% if is_valid_element(element) %}
               <tr>
-                <td class="break"><a href="element/{{ slugs.element.by_i[i] }}.html">{{ element }}</a></td>
-                <td><a href="element/{{ slugs.element.by_i[i] }}.html">{{ publishers|length }}</a></td>
+                <td class="break"><a href="{{ url_for('element', slug=slugs.element.by_i[i]) }}">{{ element }}</a></td>
+                <td><a href="{{ url_for('element', slug=slugs.element.by_i[i]) }}">{{ publishers|length }}</a></td>
                 <td>{{ current_stats.aggregated.elements[element] }}</td>
                 <td>{{ current_stats.aggregated.elements_total[element] }}</td>
               </tr>

--- a/templates/files.html
+++ b/templates/files.html
@@ -49,7 +49,7 @@
             <tbody>
                 {% for package, activities in current_stats.inverted_file.activities.items() %}
                 <tr>
-                    <td class="break"><a href="publisher/{{ package[:-4]|dataset_to_publisher }}.html">{{ publisher_name[package[:-4]|dataset_to_publisher] }}</a></td>
+                    <td class="break"><a href="{{ url_for('publisher', publisher=dataset_to_publisher(package[:-4])) }}">{{ dataset_to_publisher(publisher_name[package[:-4]]) }}</a></td>
                     <td class="break"><a href="http://iatiregistry.org/dataset/{{ package[:-4] }}">{{ package[:-4] }}</a></td>
                     <td>{{ activities }}</td>
                     <td>{{ current_stats.inverted_file.organisations.get(package) }}</td>

--- a/templates/forwardlooking.html
+++ b/templates/forwardlooking.html
@@ -61,7 +61,7 @@
             <tbody>
                 {% for row in forwardlooking.table() %}
                 <tr>
-                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="publisher/{{ row.publisher }}.html">{{ row.publisher_title }}</a></td>
+                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=row.publisher) }}">{{ row.publisher_title }}</a></td>
 
                     {% for column in row.year_columns %}
                         {% for year in forwardlooking.years %}

--- a/templates/forwardlooking.html
+++ b/templates/forwardlooking.html
@@ -20,7 +20,7 @@
     <div class="panel panel-default" id="h_table">
 
         <div class="panel-heading">
-            <span class="pull-right"><a href="{{ url('forwardlooking.csv') }}">(This table as CSV)</a></span>
+            <span class="pull-right"><a href="{{ url_for('static', filename='forwardlooking.csv') }}">(This table as CSV)</a></span>
             <h3 class="panel-title">Activities with Forward Looking Budget Allocations</h3>
         </div>
 

--- a/templates/humanitarian.html
+++ b/templates/humanitarian.html
@@ -18,7 +18,7 @@
         <div class="panel-body">
             <p>This table assesses the extent to which IATI publishers are reporting on humanitarian attributes.</p>
 
-            <p>The statistics on this page do not form part of the <a href="summary_stats.html">Summary Statstics</a>.</p>
+            <p>The statistics on this page do not form part of the <a href="{{ url_for('basic_page', page_name='summary_stats') }}">Summary Statstics</a>.</p>
 
             {% include '_partials/tablesorter_instructions.html' %}
         </div>
@@ -35,7 +35,7 @@
             <tbody>
                 {% for row in humanitarian.table() %}
                 <tr>
-                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="publisher/{{ row.publisher }}.html">{{ row.publisher_title }}</a></td>
+                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=row.publisher) }}">{{ row.publisher_title }}</a></td>
                     {% for column_slug, _ in humanitarian.columns %}
                       <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;">
                         {%- if column_slug == 'publisher_type' -%}

--- a/templates/humanitarian.html
+++ b/templates/humanitarian.html
@@ -10,7 +10,7 @@
 
     <div class="panel panel-default" id="h_table">
         <div class="panel-heading">
-            <span class="pull-right"><a href="{{ url('humanitarian.csv') }}">(This table as CSV)</a></span>
+            <span class="pull-right"><a href="{{ url_for('static', filename='humanitarian.csv') }}">(This table as CSV)</a></span>
             <h3 class="panel-title">Humanitarian</h3>
         </div>
 

--- a/templates/identifiers.html
+++ b/templates/identifiers.html
@@ -28,7 +28,7 @@
             {% set publisher_stats = get_publisher_stats(publisher) %}
             {% if publisher_stats.publisher_duplicate_identifiers|count != 0 %}
             <tr>
-                <td><a href="publisher/{{ publisher }}.html">{{ publisher_title }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
                 <td><a href="{{ stats_url }}/current/aggregated-publisher/{{ publisher }}/publisher_duplicate_identifiers.json">{{ publisher_stats.publisher_duplicate_identifiers|length }}</td>
                 <td><a href="{{ stats_url }}/current/aggregated-publisher/{{ publisher }}/publisher_duplicate_identifiers.json">{{ publisher_stats.publisher_duplicate_identifiers.values()|sum }}</td>
             </tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'section_index.html' %}
 {% block title %}Code for IATI Analytics{% endblock %}
 {% block about %}
-<p>These analytics are generated daily, with the last update based on data in the IATI Registry on <strong>{{ datetime_data }}</strong>. For more information, see the <a href="faq.html">FAQ</a>.</p>
+<p>These analytics are generated daily, with the last update based on data in the IATI Registry on <strong>{{ datetime_data }}</strong>. For more information, see the <a href="{{ url_for('basic_page', page_name='faq') }}">FAQ</a>.</p>
 <p>Many of the tables are sortable by clicking on the headers.</p>
 <p>Many of the datasets are available in machine readable JSON format. Some links to JSON are abbreviated to <code>(J)</code>.</p>
 {% endblock %}
@@ -18,7 +18,7 @@
         <tbody>
             <tr>
                 <td id="activities-count">
-                    <a href="activities.html">
+                    <a href="{{ url_for('basic_page', page_name='activities') }}">
                     {{ current_stats.aggregated.activities }}
                     </a>
                 </td>
@@ -26,7 +26,7 @@
             </tr>
             <tr>
                 <td id="unique-activities-count">
-                    <a href="activities.html">
+                    <a href="{{ url_for('basic_page', page_name='activities') }}">
                     {{ current_stats.aggregated.iati_identifiers|count }}
                     </a>
                 </td>
@@ -34,7 +34,7 @@
             </tr>
             <tr>
                 <td id="publishers-count">
-                    <a href="publishers.html">
+                    <a href="{{ url_for('basic_page', page_name='publishers') }}">
                     {{ current_stats.aggregated.publishers }}
                     </a>
                 </td>
@@ -42,7 +42,7 @@
             </tr>
             <tr>
                 <td id="activity-files-count">
-                    <a href="files.html">
+                    <a href="{{ url_for('basic_page', page_name='files') }}">
                     {{ current_stats.aggregated.activity_files }}
                     </a>
                 </td>
@@ -50,7 +50,7 @@
             </tr>
             <tr>
                 <td id="organisation-files-count">
-                    <a href="files.html">
+                    <a href="{{ url_for('basic_page', page_name='files') }}">
                     {{ current_stats.aggregated.organisation_files }}
                     </a>
                 </td>
@@ -58,7 +58,7 @@
             </tr>
             <tr>
                 <td id="total-file-size">
-                    <a href="files.html">
+                    <a href="{{ url_for('basic_page', page_name='files') }}">
                     {{ current_stats.aggregated.file_size|filesizeformat }}
                     </a>
                 </td>
@@ -66,7 +66,7 @@
             </tr>
             <tr>
                 <td id="failed-download-count">
-                    <a href="download.html">
+                    <a href="{{ url_for('basic_page', page_name='download') }}">
                     {{ current_stats.download_errors|length }}
                     </a>
                 </td>
@@ -74,7 +74,7 @@
             </tr>
             <tr>
                 <td id="poorly-formed-xml-file-count">
-                    <a href="xml.html">
+                    <a href="{{ url_for('basic_page', page_name='xml') }}">
                     {{ current_stats.aggregated.invalidxml }}
                     </a>
                 </td>
@@ -82,7 +82,7 @@
             </tr>
             <tr>
                 <td id="non-standard-roots-file-count">
-                    <a href="xml.html">
+                    <a href="{{ url_for('basic_page', page_name='xml') }}">
                     {{ current_stats.aggregated.nonstandardroots }}
                     </a>
                 </td>
@@ -96,7 +96,7 @@
             </tr>
             <tr>
                 <td id="cannot-validate-file-count">
-                    <a href="validation.html">
+                    <a href="{{ url_for('basic_page', page_name='validation') }}">
                     {{ current_stats.aggregated.validation.fail }}
                     </a>
                 </td>
@@ -104,7 +104,7 @@
             </tr>
             <tr>
                 <td id="publishers-with-non-valid-files-count">
-                    <a href="validation.html">
+                    <a href="{{ url_for('basic_page', page_name='validation') }}">
                     {{ current_stats.aggregated.publishers_validation.fail }}
                     </a>
                 </td>
@@ -112,7 +112,7 @@
             </tr>
             <tr>
                 <td id="publishers-with-no-org-file-count">
-                    <a href="organisation.html">
+                    <a href="{{ url_for('basic_page', page_name='organisation') }}">
                     {{ current_stats.aggregated.publisher_has_org_file.no }}
                     </a>
                 </td>

--- a/templates/license.html
+++ b/templates/license.html
@@ -22,7 +22,7 @@
             <tbody>
                 {% for publisher, files in publisher_counts %}
                 <tr>
-                    <td><a href="../publisher/{{ publisher }}.html">{{ publisher }}</a></td>
+                    <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
                     <td>{{ files }}</td>
                 </tr>
                 {% endfor %}

--- a/templates/licenses.html
+++ b/templates/licenses.html
@@ -23,7 +23,7 @@
                     <td>{% if license_urls[license]['url'] %}<a href="{{ license_urls[license]['url'] }}">{{ license_names[license] }}</a>{% else %}{{ license_names[license] }}{% endif %}</td>
                     <td>{{ license }}</td>
                     <td>{{ files }}</td>
-                    <td><a href="license/{{ license }}.html">{{ publisher_license_count[license] }}</a></td>
+                    <td><a href="{{ url_for('licenses_individual_license', license=license) }}">{{ publisher_license_count[license] }}</a></td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/templates/organisation.html
+++ b/templates/organisation.html
@@ -17,7 +17,7 @@
             <p>The following publishers do not have an organisation file listed on the IATI Registry.</p>
             <ul>
             {% for publisher in sorted(current_stats.inverted_publisher.publisher_has_org_file.no) %}
-              <li><a href="publisher/{{ publisher }}.html">{{ publisher_name[publisher] }}</a></li>
+              <li><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_name[publisher] }}</a></li>
             {% endfor %}
             </ul>
           </div>

--- a/templates/publisher.html
+++ b/templates/publisher.html
@@ -108,7 +108,7 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
                 <td>Licenses</td>
                 <td>
                 {% for license in publisher_licenses %}
-                <code><a href="../license/{{ license }}.html">{{ license }}</a></code>
+                <code><a href="{{ url_for('licenses_individual_license', license=license) }}">{{ license }}</a></code>
                 {% endfor %}
                 </td>
             </tr><tr>

--- a/templates/publisher.html
+++ b/templates/publisher.html
@@ -377,7 +377,7 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
             {% for element, values in publisher_stats.codelist_values_by_major_version[major_version].items() %}
             <tr>
             {% with element_i=element_list.index(element) %}
-                <td><a href="{{ url('codelist/{}/{}.html'.format(major_version, slugs.codelist[major_version].by_i[element_i])) }}">{{ element }}</a></td>
+                <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[element_i]) }}">{{ element }}</a></td>
                 <td><a href="https://codelists.codeforiati.org/{{ codelist_mapping[major_version].get(element) }}">{{ codelist_mapping[major_version].get(element) }}</a></td>
                 {% with codes=sorted(codelist_sets[major_version].get(codelist_mapping[major_version].get(element)).intersection(values.keys())) %}
                 <td>{% if codes|count %}
@@ -425,9 +425,9 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
             {% for element, count in publisher_stats['elements'].items() %}
             <tr>
             {% with element_i=element_list.index(element) %}
-                <td><a href="{{ url('element/{0}.html'.format(slugs.element.by_i[element_i])) }}">{{ element }}</a></td>
+                <td><a href="{{ url_for('element', slug=slugs.element.by_i[element_i]) }}">{{ element }}</a></td>
                 <td>{{ count }}</td>
-                <td><a href="{{ url('element/{0}.html'.format(slugs.element.by_i[element_i])) }}#files_{{ publisher }}">{{ publisher_inverted.elements[element]|count }}</a></td>
+                <td><a href="{{ url_for('element', slug=slugs.element.by_i[element_i]) }}#files_{{ publisher }}">{{ publisher_inverted.elements[element]|count }}</a></td>
             {% endwith %}
             </tr>
             {% endfor %}

--- a/templates/publishers.html
+++ b/templates/publishers.html
@@ -13,7 +13,7 @@
     <div class="col-xs-12">
     <div class="panel panel-default">
     <div class="panel-body">
-        <p style="float:right"><a href="{{ url('publishers.csv') }}">(This table as CSV)</a></p>
+        <p style="float:right"><a href="{{ url_for('static', filename='publishers.csv') }}">(This table as CSV)</a></p>
         <p>List of current active IATI publishers,  Click on the publisher name for more details.</p>
         {% include '_partials/tablesorter_instructions.html' %}
     </div>

--- a/templates/publishers.html
+++ b/templates/publishers.html
@@ -34,8 +34,8 @@
             {% for publisher_title,publisher in publishers_ordered_by_title %}
             {% set publisher_stats = get_publisher_stats(publisher) %}
             <tr>
-                <td><a href="publisher/{{ publisher }}.html">{{ publisher_name[publisher] }}</a></td>
-                <td><a href="publisher/{{ publisher }}.html">{{ publisher }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_name[publisher] }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
                 <td>{{ current_stats.inverted_publisher.activities[publisher] }}</td>
                 <td>{{ publisher_stats.organisations }}</td>
                 <td>{{ current_stats.inverted_publisher.activity_files.get(publisher)+current_stats.inverted_publisher.organisation_files.get(publisher) }}</td>

--- a/templates/registration_agencies.html
+++ b/templates/registration_agencies.html
@@ -51,8 +51,8 @@
 {% for publisher, count in publishers.items() %}
     <tr>
         <td><code>{{ orgid|replace(' ', ' ') }}</code></td>
-        <td><a href="publisher/{{ publisher }}.html">{{ publisher }}</a></td>
-        <td><a href="publisher/{{ publisher }}.html">{{ publisher_name[publisher] }}</a></td>
+        <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
+        <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_name[publisher] }}</a></td>
         <td>{{ count }}</td>
     </tr>
 {% endfor %}

--- a/templates/reporting_orgs.html
+++ b/templates/reporting_orgs.html
@@ -26,7 +26,7 @@
         {% set reporting_orgs_key = publisher_stats.reporting_orgs.keys()|first %}
         {% if publisher_stats.reporting_orgs|count != 1 or reporting_orgs_key != ckan_publishers[publisher].result.publisher_iati_id %}
         <tr>
-            <td><a href="publisher/{{ publisher }}.html">{{ publisher_title }}</a></td>
+            <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
             <td><code>{{ ckan_publishers[publisher].result.publisher_iati_id }}</code></td>
             <td>{{ publisher_stats.reporting_orgs|length }}</td>
             <td>{% for ro in publisher_stats.reporting_orgs %}<code>{{ ro }}</code> {% endfor %}</td>

--- a/templates/section_index.html
+++ b/templates/section_index.html
@@ -27,12 +27,10 @@
       </div>
       <ul class="list-group">
       {% for item in (top_navigation if page=='index' else navigation[navigation_reverse[page]]) %}
-        {% if item!='index' %}
-          <li class="list-group-item">
-          <h4><a href="{{ url(item+'.html') }}">{{ page_titles[item] }}</a></h4>
-          <p>{{ page_leads[item]|safe }}</p>
-          </li>
-        {% endif %}
+        <li class="list-group-item">
+        <h4><a href="{{ url_for('basic_page', page_name=item) }}">{{ page_titles[item] }}</a></h4>
+        <p>{{ page_leads[item]|safe }}</p>
+        </li>
       {% endfor %}
       </ul>
     </div>

--- a/templates/summary_stats.html
+++ b/templates/summary_stats.html
@@ -37,7 +37,7 @@
             <tbody>
                 {% for row in summary_stats.table() %}
                 <tr>
-                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="publisher/{{ row.publisher }}.html">{{ row.publisher_title }}</a></td>
+                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=row.publisher) }}">{{ row.publisher_title }}</a></td>
                     {% for column_slug, column_header in summary_stats.columns %}
                     <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;">{% if column_slug == "publisher_type" %}{{ row[column_slug] }}{% else %}{{ row[column_slug] | round_nicely }}{% endif %}</th>
                     {% endfor %}
@@ -55,10 +55,10 @@
         </div>
         <div class="panel-body">
             <h4>Timeliness</h5>
-            <p>This is calculated by scoring the assessments made on the <a href="timeliness.html">
-               frequency</a> and <a href="timeliness_timelag.html">timelag</a> pages on a scale of
+            <p>This is calculated by scoring the assessments made on the <a href="{{ url_for('basic_page', page_name='timeliness') }}">
+               frequency</a> and <a href="{{ url_for('basic_page', page_name='timeliness_timelag') }}">timelag</a> pages on a scale of
                0 to 4 (as below), dividing the sum of the two scores by 8, and expressing the result as
-               a percentage. The methodology used in making the assesments is detailed on the <a href="timeliness.html">frequency</a> and <a href="timeliness_timelag.html">timelag</a> pages.
+               a percentage. The methodology used in making the assesments is detailed on the <a href="{{ url_for('basic_page', page_name='timeliness') }}">frequency</a> and <a href="{{ url_for('basic_page', page_name='timeliness_timelag') }}">timelag</a> pages.
             </p>
 
             <table class="table table-striped">
@@ -118,12 +118,12 @@
 
             <h4>Forward looking</h4>
             <p>The average percentage of current activities with budgets for each of the years {{ current_year }} - {{ current_year + 2 }}.
-               The component values and a detailed methodology are displayed on the <a href="forwardlooking.html">forward looking</a> page.
+               The component values and a detailed methodology are displayed on the <a href="{{ url_for('basic_page', page_name='forwardlooking') }}">forward looking</a> page.
             </p>
 
 
             <h4>Comprehensiveness</h4>
-            <p>The average of <a href="comprehensiveness.html">comprehensiveness</a> averages for core, financials and value-added. The core average has a double-weighting.</p>
+            <p>The average of <a href="{{ url_for('basic_page', page_name='comprehensiveness') }}">comprehensiveness</a> averages for core, financials and value-added. The core average has a double-weighting.</p>
 
 
             <h4>Score</h4>

--- a/templates/summary_stats.html
+++ b/templates/summary_stats.html
@@ -12,7 +12,7 @@
 
     <div class="panel panel-default" id="h_table">
         <div class="panel-heading">
-            <span class="pull-right"><a href="{{ url('summary_stats.csv') }}">(This table as CSV)</a></span>
+            <span class="pull-right"><a href="{{ url_for('static', filename='summary_stats.csv') }}">(This table as CSV)</a></span>
             <h3 class="panel-title">Summary Statistics</h3>
         </div>
 

--- a/templates/timeliness.html
+++ b/templates/timeliness.html
@@ -7,7 +7,7 @@
     <div class="panel panel-default" id="h_table">
 
         <div class="panel-heading">
-            <span class="pull-right"><a href="{{ url('timeliness_frequency.csv') }}">(This table as CSV)</a></span>
+            <span class="pull-right"><a href="{{ url_for('static', filename='timeliness_frequency.csv') }}">(This table as CSV)</a></span>
             <h3 class="panel-title">Table of Frequency assessments</h3>
         </div>
 

--- a/templates/timeliness.html
+++ b/templates/timeliness.html
@@ -45,7 +45,7 @@
             <tbody>
                 {% for publisher, publisher_title, per_month, assessment, hft, first_published_band in timeliness.publisher_frequency_sorted() %}
                 <tr>
-                    <td style="border-right: 1px solid #ddd;"><a href="publisher/{{ publisher }}.html">{{ publisher_title }}</a></td>
+                    <td style="border-right: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
                     <td data-index="{{ timeliness.first_published_band_index(first_published_band) }}" style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;">{{ first_published_band }}</td>
                     {% for month in timeliness.previous_months_reversed %}
                     <td {% if not per_month[month] %}class="text-muted"{% endif %}>{{ per_month[month] or 0 }}</td>

--- a/templates/timeliness_base.html
+++ b/templates/timeliness_base.html
@@ -8,8 +8,8 @@
     {% endblock %}
 
     <ul class="nav nav-tabs" role="tablist">
-      <li{% block frequency_li %}{% endblock %}><a href="timeliness.html">Frequency</a></li>
-      <li{% block timelag_li %}{% endblock %}><a href="timeliness_timelag.html">Time lag</a></li>
+      <li{% block frequency_li %}{% endblock %}><a href="{{ url_for('basic_page', page_name='timeliness') }}">Frequency</a></li>
+      <li{% block timelag_li %}{% endblock %}><a href="{{ url_for('basic_page', page_name='timeliness_timelag') }}">Time lag</a></li>
     </ul>
 
     <ul class="list-inline" style="padding: 1em">

--- a/templates/timeliness_timelag.html
+++ b/templates/timeliness_timelag.html
@@ -42,7 +42,7 @@
             <tbody>
                 {% for publisher, publisher_title, per_month, assessment, hft in timeliness.publisher_timelag_sorted() %}
                 <tr>
-                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="publisher/{{ publisher }}.html">{{ publisher_title }}</a></td>
+                    <td style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
                     {% for month in timeliness.previous_months_reversed %}
                     <td {% if not per_month[month] %}class="text-muted"{% endif %}>{{ per_month[month] or 0 }}</td>
                     {% endfor %}

--- a/templates/timeliness_timelag.html
+++ b/templates/timeliness_timelag.html
@@ -7,7 +7,7 @@
     <div class="panel panel-default" id="h_table">
 
         <div class="panel-heading">
-            <span class="pull-right"><a href="{{ url('timeliness_timelag.csv') }}">(This table as CSV)</a></span>
+            <span class="pull-right"><a href="{{ url_for('static', filename='timeliness_timelag.csv') }}">(This table as CSV)</a></span>
             <h3 class="panel-title">Table of Time lag assessments</h3>
         </div>
 

--- a/templates/traceability.html
+++ b/templates/traceability.html
@@ -26,7 +26,7 @@
               {% for publisher_title,publisher in publishers_ordered_by_title %}
               {% set publisher_stats = get_publisher_stats(publisher) %}
                   <tr>
-                      <td><a href="publisher/{{ publisher }}.html">{{ publisher_title }}</a></td>
+                      <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
                       <td>
                         {%- if publisher_stats.traceable_activities_by_publisher_id -%}
                           {{ '{:,}'.format(publisher_stats.traceable_activities_by_publisher_id) }}

--- a/templates/validation.html
+++ b/templates/validation.html
@@ -24,7 +24,7 @@
         {% if datasets %}
         <div class="panel panel-default">
           <!-- Default panel contents -->
-          <div class="panel-heading"><a href="publisher/{{ publisher }}.html" id="list_{{ publisher }}">{{ publisher_name[publisher ] }}</a> ({{ datasets|length }})</div>
+          <div class="panel-heading"><a href="{{ url_for('publisher', publisher=publisher) }}" id="list_{{ publisher }}">{{ publisher_name[publisher ] }}</a> ({{ datasets|length }})</div>
           <!--<div class="panel-body">
             <p>...</p>
           </div>-->

--- a/templates/versions.html
+++ b/templates/versions.html
@@ -68,7 +68,7 @@
               <table class="table table-striped">
                 {% for publisher in publishers %}
                 <tr>
-                  <td><a href="publisher/{{ publisher }}.html">{{ publisher_name[publisher] }}</a></td>
+                  <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_name[publisher] }}</a></td>
                 </tr>
                 {% endfor %}
               </table>
@@ -95,7 +95,7 @@
               <table class="table table-striped">
                 {% for publisher in publishers %}
                 <tr>
-                  <td><a href="publisher/{{ publisher }}.html">{{ publisher_name[publisher] }}</a></td>
+                  <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_name[publisher] }}</a></td>
                 </tr>
                 {% endfor %}
               </table>

--- a/templates/versions.html
+++ b/templates/versions.html
@@ -29,7 +29,7 @@
             {% for publisher in current_stats.inverted_file_publisher %}
               {% with datasets = current_stats.inverted_file_publisher[publisher].version_mismatch.get('true', {}) %}
                 {% if datasets %}
-                <tr><td id="files_{{ publisher }}"><a href="{{ url('publisher/{0}.html'.format(publisher)) }}">{{ publisher_name[publisher] }}</a></td><td>
+                <tr><td id="files_{{ publisher }}"><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_name[publisher] }}</a></td><td>
                 {% for dataset in datasets.keys() %}
                     <a href="http://iatiregistry.org/dataset/{{ dataset[:-4] }}">{{ dataset[:-4] }}</a>
                 {% endfor %}

--- a/templates/xml.html
+++ b/templates/xml.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="row">
       {{ boxes.box('Files where XML is not well-formed', current_stats.aggregated.invalidxml, 'invalidxml.png', 'invalidxml.json',
-        description='Count of files where the XML that is not well-formed, over time. Note: this is different from <a href="validation.html">validation against the schema</a>.') }}
+        description='Count of files where the XML that is not well-formed, over time. Note: this is different from <a href="{}">validation against the schema</a>.'.format(url_for('basic_page', page_name='validation'))) }}
       {{ boxes.box('Files with non-standard roots', current_stats.aggregated.nonstandardroots, 'nonstandardroots.png', 'nonstandardroots.json',
         description='Count of files with non-standard root, over time. Note: Files with non-standard roots are those where the root XML element is not <code>iati-activities</code> or <code>iati-organisation</code> as we would expect.</p>') }}
     </div>
@@ -28,7 +28,7 @@
             {% for dataset, invalid in current_stats.inverted_file.invalidxml.items() %}
             {% if invalid %}
             <tr>
-                <td><a href="publisher/{{ dataset[:-4]|dataset_to_publisher }}.html">{{ dataset[:-4]|dataset_to_publisher }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=dataset_to_publisher(dataset[:-4])) }}">{{ dataset_to_publisher(dataset[:-4]) }}</a></td>
                 <td><a href="http://iatiregistry.org/dataset/{{ dataset[:-4] }}">{{ dataset[:-4] }}</a></td>
             </tr>
             {% endif %}
@@ -55,7 +55,7 @@
             {% for dataset, nonstandard in current_stats.inverted_file.nonstandardroots.items() %}
             {% if nonstandard %}
             <tr>
-                <td><a href="publisher/{{ dataset[:-4]|dataset_to_publisher }}.html">{{ dataset[:-4]|dataset_to_publisher }}</a></td>
+                <td><a href="{{ url_for('publisher', publisher=dataset_to_publisher(dataset[:-4])) }}">{{ dataset_to_publisher(dataset[:-4]) }}</a></td>
                 <td><a href="http://iatiregistry.org/dataset/{{ dataset[:-4] }}">{{ dataset[:-4] }}</a></td>
             </tr>
             {% endif %}

--- a/text.py
+++ b/text.py
@@ -94,7 +94,7 @@ short_page_titles.update({
     'identifiers': 'Duplicate Identifiers',
 })
 
-top_navigation = ['index', 'headlines', 'data_quality', 'publishing_stats', 'exploring_data', 'faq']
+top_navigation = ['headlines', 'data_quality', 'publishing_stats', 'exploring_data', 'faq']
 navigation = {
     'headlines': ['publishers', 'files', 'activities'],
     'data_quality': ['download', 'xml', 'validation', 'versions', 'licenses', 'organisation', 'identifiers', 'reporting_orgs'],

--- a/timeliness.py
+++ b/timeliness.py
@@ -1,6 +1,6 @@
 # This file converts raw timeliness data into the associated Publishing Statistics assessments
 
-from data import JSONDir, publisher_name, get_publisher_stats, get_registry_id_matches
+from data import JSONDir, publishers_ordered_by_title, publisher_name, get_publisher_stats, get_registry_id_matches
 import datetime
 from dateutil.relativedelta import relativedelta
 from collections import defaultdict, Counter
@@ -61,7 +61,9 @@ def publisher_frequency():
     gitaggregate_publisher = JSONDir('./stats-calculated/gitaggregate-publisher-dated')
 
     # Loop over each publisher - i.e. a publisher folder within 'gitaggregate-publisher-dated'
-    for publisher, agg in gitaggregate_publisher.items():
+
+    for publisher_title, publisher in publishers_ordered_by_title:
+        agg = gitaggregate_publisher[publisher]
 
         # Skip to the next publisher if there is no data for 'most_recent_transaction_date' for this publisher
         if 'most_recent_transaction_date' not in agg:
@@ -135,9 +137,8 @@ def publisher_frequency():
                 # There has been an update in none of the last 12 months
                 frequency = 'Less than Annual'
 
-        # If the publisher is in the list of current publishers, return a generator object
-        if publisher in publisher_name:
-            yield publisher, publisher_name.get(publisher), updates_per_month, frequency, hft, first_published_band
+        # return a generator object
+        yield publisher, publisher_title, updates_per_month, frequency, hft, first_published_band
 
 
 def frequency_index(frequency):


### PR DESCRIPTION
Instead of manually constructing URLs, let’s let flask’s `url_for` do it.

This makes it easier to modify URL structures later, as well as helping us spot any unexpected 404s.