### PR TITLE
Remove .html from paths

### DIFF
--- a/templates/codelist.html
+++ b/templates/codelist.html
@@ -11,24 +11,6 @@
 
 {% block content %}
     <div class="row">
-      <div class="col-xs-12">
-        <p>
-        {% with elements=reverse_codelist_mapping[major_version][codelist_mapping[element]] %}
-        {% if elements|count > 1 %}
-        Other elements/attributes on this codelist:
-        <ul>
-        {% for el in elements %}
-        {% if el in current_stats.inverted_publisher.codelist_values[major_version].keys() %}
-        {% if el!=element %}<li><a href="{{ slugs.codelist[major_version].by_i[current_stats.inverted_publisher.codelist_values[major_version].keys().index(el)] }}.html">{{ el }}</a></li>{% endif %}
-        {% endif %}
-        {% endfor %}
-        </ul>
-        {% endif %}
-        {% endwith %}</p>
-      </div>
-    </div>
-
-    <div class="row">
       <div class="col-md-6">
         <div class="panel panel-default">
           <div class="panel-heading">
@@ -75,6 +57,24 @@
             </tbody>
           </table>
         </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-xs-12">
+        <p>
+        {% with elements=reverse_codelist_mapping[major_version][codelist_mapping[major_version][element]] %}
+        {% if elements|count > 1 %}
+        {% with element_list=current_stats.inverted_publisher.codelist_values_by_major_version[major_version].keys()|list %}
+        Other elements/attributes on this codelist:
+        <ul>
+        {% for el in elements %}
+        {% if el != element and el in element_list %}<li><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[element_list.index(el)]) }}">{{ el }}</a></li>{% endif %}
+        {% endfor %}
+        </ul>
+        {% endwith %}
+        {% endif %}
+        {% endwith %}</p>
       </div>
     </div>
 {% endblock %}

--- a/templates/comprehensiveness_base.html
+++ b/templates/comprehensiveness_base.html
@@ -9,9 +9,9 @@
 
     <ul class="nav nav-tabs" role="tablist">
       <li{% if tab=='summary' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness') }}">Summary</a></li>
-      <li{% if tab=='core' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness_core') }}">Core</a></li>
-      <li{% if tab=='financials' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness_financials') }}">Financials</a></li>
-      <li{% if tab=='valueadded' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness_valueadded') }}">Value added</a></li>
+      <li{% if tab=='core' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness-core') }}">Core</a></li>
+      <li{% if tab=='financials' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness-financials') }}">Financials</a></li>
+      <li{% if tab=='valueadded' %} class="active"{% endif %}><a href="{{ url_for('basic_page', page_name='comprehensiveness-valueadded') }}">Value added</a></li>
     </ul>
 
     <ul class="list-inline" style="padding: 1em">

--- a/templates/comprehensiveness_core.html
+++ b/templates/comprehensiveness_core.html
@@ -5,7 +5,7 @@
 {% block heading_detail %}
 	<p>Core elements are those that are mandatory in version 2.01 of the IATI Activity standard. The core elements are: Version, Reporting Organisation, IATI Identifier, Participating Organisation, Title, Description, Status, Activity Date, Sector, and Country or Region.</p>
 
-	<p>This table shows the percentage of <strong><em>current</em></strong> activities where the core elements are populated with valid data. (Values in parentheses indicate percentage of activities where elements are populated with any data.) The scoring for the <a href="{{ url_for('basic_page', page_name='summary_stats') }}">Summary Stats page</a> recognises the importance of the core by giving it double weighting in the overall comprehensiveness component.</p>
+	<p>This table shows the percentage of <strong><em>current</em></strong> activities where the core elements are populated with valid data. (Values in parentheses indicate percentage of activities where elements are populated with any data.) The scoring for the <a href="{{ url_for('basic_page', page_name='summary-stats') }}">Summary Stats page</a> recognises the importance of the core by giving it double weighting in the overall comprehensiveness component.</p>
 
 	<p><strong>Key:</strong><br/>
         Dashes: Where a publisher has published to IATI in the past but whose portfolio contains no current activities.

--- a/templates/coverage.html
+++ b/templates/coverage.html
@@ -10,7 +10,7 @@
 
         <p>
             Previously, the IATI technical team followed a manual process of contacting IATI publishers and requesting total operational spend values via email.
-            Results were stored in a <a href="https://docs.google.com/spreadsheets/d/1SgE6sXbzD2y8p3QzBcY4kAqkCTG1eUld5QuSvCfKVUE/edit#gid=2132486785">public Google sheet</a>. Data was collected for the years 2014 and 2015 and the values were used to calculate a coverage-adjusted score in the <a href="{{ url_for('basic_page', page_name='summary_stats') }}">Summary Statistics page.</a>
+            Results were stored in a <a href="https://docs.google.com/spreadsheets/d/1SgE6sXbzD2y8p3QzBcY4kAqkCTG1eUld5QuSvCfKVUE/edit#gid=2132486785">public Google sheet</a>. Data was collected for the years 2014 and 2015 and the values were used to calculate a coverage-adjusted score in the <a href="{{ url_for('basic_page', page_name='summary-stats') }}">Summary Statistics page.</a>
             As this was a very time consuming exercise (compounded by the increase in the number of publishers) coverage data collection has not been done since 2016, resulting in the coverage-adjusted scores in the summary statistics being out of date for the majority of publishers.
             As a result, in <a href="https://discuss.iatistandard.org/t/iati-coverage-timing-and-scope-of-next-update/1141/15">September 2018 the technical team took the decision</a> to remove the coverage-adjusted values.
         </p>

--- a/templates/humanitarian.html
+++ b/templates/humanitarian.html
@@ -18,7 +18,7 @@
         <div class="panel-body">
             <p>This table assesses the extent to which IATI publishers are reporting on humanitarian attributes.</p>
 
-            <p>The statistics on this page do not form part of the <a href="{{ url_for('basic_page', page_name='summary_stats') }}">Summary Statstics</a>.</p>
+            <p>The statistics on this page do not form part of the <a href="{{ url_for('basic_page', page_name='summary-stats') }}">Summary Statstics</a>.</p>
 
             {% include '_partials/tablesorter_instructions.html' %}
         </div>

--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Code for IATI Analytics</title>
+    <meta http-equiv="refresh" content="0;URL='{{ url }}'" />
+  </head>
+  <body>
+    <p>This page has moved to <a href="{{ url }}">{{ url }}</a>.</p>
+  </body>
+</html>

--- a/templates/summary_stats.html
+++ b/templates/summary_stats.html
@@ -56,9 +56,9 @@
         <div class="panel-body">
             <h4>Timeliness</h5>
             <p>This is calculated by scoring the assessments made on the <a href="{{ url_for('basic_page', page_name='timeliness') }}">
-               frequency</a> and <a href="{{ url_for('basic_page', page_name='timeliness_timelag') }}">timelag</a> pages on a scale of
+               frequency</a> and <a href="{{ url_for('basic_page', page_name='timeliness-timelag') }}">timelag</a> pages on a scale of
                0 to 4 (as below), dividing the sum of the two scores by 8, and expressing the result as
-               a percentage. The methodology used in making the assesments is detailed on the <a href="{{ url_for('basic_page', page_name='timeliness') }}">frequency</a> and <a href="{{ url_for('basic_page', page_name='timeliness_timelag') }}">timelag</a> pages.
+               a percentage. The methodology used in making the assesments is detailed on the <a href="{{ url_for('basic_page', page_name='timeliness') }}">frequency</a> and <a href="{{ url_for('basic_page', page_name='timeliness-timelag') }}">timelag</a> pages.
             </p>
 
             <table class="table table-striped">

--- a/templates/timeliness_base.html
+++ b/templates/timeliness_base.html
@@ -9,7 +9,7 @@
 
     <ul class="nav nav-tabs" role="tablist">
       <li{% block frequency_li %}{% endblock %}><a href="{{ url_for('basic_page', page_name='timeliness') }}">Frequency</a></li>
-      <li{% block timelag_li %}{% endblock %}><a href="{{ url_for('basic_page', page_name='timeliness_timelag') }}">Time lag</a></li>
+      <li{% block timelag_li %}{% endblock %}><a href="{{ url_for('basic_page', page_name='timeliness-timelag') }}">Time lag</a></li>
     </ul>
 
     <ul class="list-inline" style="padding: 1em">


### PR DESCRIPTION
Fixes #78.

This should also add all the requisite redirects. These redirects are a bit ugly, and (I haven’t tried but) I suspect they don’t work on a development server.